### PR TITLE
Add 2x new sensor types to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,5 @@ Possible values for an I2C component's subcomponents' `sensorType` field:
 - "pm25-env"
 - "pm100-env"
 - "co2"
+- "gas-resistance"
+- "altitude"


### PR DESCRIPTION
Adding new sensor types (https://github.com/adafruit/Wippersnapper_Protobuf/pull/86) to README.rst