### PR TITLE
Adds issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/component-request.md
+++ b/.github/ISSUE_TEMPLATE/component-request.md
@@ -1,0 +1,18 @@
+
+---
+name: Component Request
+about: Suggest a new component for Adafruit.io WipperSnapper
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**What's the full name of the component you'd like to see in Adafruit.io WipperSnapper?**
+The full name of the specific component.
+
+**Product URL or Datasheet**
+Add a link to the product's URL or datasheet here.
+
+**Additional context**
+Add any other context about the component request here.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Welcome! This repository contains JSON definition files and images that allow co
 
 **Note: We aren't ready for user submissions yet as we're still finalizing the format and tools.**
 
+[Click here to submit suggestions or requests for new Adafruit.io WipperSnapper components >>>](https://github.com/adafruit/WipperSnapper_Components/issues/new/choose)
+
 ## How Will It Work?
 
 Anyone can add a new component to Wippersnapper by writing a small amount of descriptive JSON and adding an image! If accepted, a supported component will:


### PR DESCRIPTION
Once merged, we can delete https://github.com/adafruit/WipperSnapper_Component_Requests

Issues from https://github.com/adafruit/WipperSnapper_Component_Requests have been transferred over.