### PR TITLE
Fix tvoc Sensor Type error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,3 @@ Possible values for an I2C component's subcomponents' `sensorType` field:
 - "co2"
 - "gas-resistance"
 - "altitude"
-- "tvoc"

--- a/components/i2c/bme680/definition.json
+++ b/components/i2c/bme680/definition.json
@@ -24,7 +24,7 @@
     },
     {
       "displayName":"Total VOC",
-      "sensorType":"tvoc",
+      "sensorType":"gas-resistance",
       "defaultPeriod":900
     }
   ]

--- a/components/i2c/schema.json
+++ b/components/i2c/schema.json
@@ -22,7 +22,7 @@
         "sensorType": {
           "description": "One of the supported I2C sensor type strings (found in README).",
           "type": "string",
-          "pattern": "^(unspecified|accelerometer|magnetic-field|orientation|gyroscope|light|pressure|proximity|gravity|acceleration|rotation|humidity|ambient-temp|object-temp|voltage|current|color|raw|pm10-std|pm25-std|pm100-std|pm10-env|pm25-env|pm100-env|co2|altitude|gas-resistance|tvoc)$"
+          "pattern": "^(unspecified|accelerometer|magnetic-field|orientation|gyroscope|light|pressure|proximity|gravity|acceleration|rotation|humidity|ambient-temp|object-temp|voltage|current|color|raw|pm10-std|pm25-std|pm100-std|pm10-env|pm25-env|pm100-env|co2|gas-resistance|altitude)$"
         },
         "defaultPeriod": {
           "description": "What period to the form should default to for this sensor.",


### PR DESCRIPTION
oops i added a bad sensor type:
`tvoc` was already in there as `gas-resistance`