### PR TITLE
Considering an I2C refactor

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,8 +4,8 @@ name: Validate JSONs
 on: [pull_request]
 
 jobs:
-  validate-definition-files:
-    name: Validate Definition Files
+  validate-pin-component-definitions:
+    name: Validate Pin Component Definition Files
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -15,6 +15,12 @@ jobs:
         with:
           schema: /components/pin/schema.json
           jsons: components/pin/*/definition.json
+
+  validate-i2c-component-definitions:
+    name: Validate I2C Component Definition Files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
       - name: Validate I2C Components
         uses: nhalstead/validate-json-action@0.1.3

--- a/components/i2c/SHT40/definition.json
+++ b/components/i2c/SHT40/definition.json
@@ -1,16 +1,5 @@
 {
   "displayName": "SHT40",
   "i2cAddresses": [ "0x44" ],
-  "subcomponents": [
-    {
-      "displayName": "Temperature Sensor",
-      "sensorType": "ambient-temp",
-      "defaultPeriod": 900
-    },
-    {
-      "displayName": "Humidity Sensor",
-      "sensorType": "humidity",
-      "defaultPeriod": 900
-    }
-  ]
+  "subcomponents": [ "ambient-temp", "humidity" ]
 }

--- a/components/i2c/aht20/definition.json
+++ b/components/i2c/aht20/definition.json
@@ -1,16 +1,5 @@
 {
   "displayName": "AHT20",
   "i2cAddresses": [ "0x38" ],
-  "subcomponents": [
-    {
-      "displayName": "Temperature Sensor",
-      "sensorType": "ambient-temp",
-      "defaultPeriod": 900
-    },
-    {
-      "displayName": "Humidity Sensor",
-      "sensorType": "humidity",
-      "defaultPeriod": 900
-    }
-  ]
+  "subcomponents": [ "ambient-temp", "humidity" ]
 }

--- a/components/i2c/bme280/definition.json
+++ b/components/i2c/bme280/definition.json
@@ -1,26 +1,5 @@
 {
     "displayName":"BME280",
     "i2cAddresses": [ "0x76", "0x77" ],
-    "subcomponents":[
-       {
-          "displayName":"Temperature Sensor",
-          "sensorType":"ambient-temp",
-          "defaultPeriod":900
-       },
-       {
-          "displayName":"Humidity Sensor",
-          "sensorType":"humidity",
-          "defaultPeriod":900
-       },
-       {
-          "displayName":"Pressure Sensor",
-          "sensorType":"pressure",
-          "defaultPeriod":900
-       },
-       {
-          "displayName":"Altitude (Relative)",
-          "sensorType":"altitude",
-          "defaultPeriod":900
-       }
-    ]
+    "subcomponents": [ "ambient-temp", "humidity", "pressure", "altitude" ]
 }

--- a/components/i2c/bme680/definition.json
+++ b/components/i2c/bme680/definition.json
@@ -1,31 +1,5 @@
 {
   "displayName": "BME680",
   "i2cAddresses": [ "0x76", "0x77" ],
-  "subcomponents": [
-    {
-       "displayName":"Temperature Sensor",
-       "sensorType":"ambient-temp",
-       "defaultPeriod":900
-    },
-    {
-       "displayName":"Humidity Sensor",
-       "sensorType":"humidity",
-       "defaultPeriod":900
-    },
-    {
-       "displayName":"Pressure Sensor",
-       "sensorType":"pressure",
-       "defaultPeriod":900
-    },
-    {
-       "displayName":"Altitude (Relative)",
-       "sensorType":"altitude",
-       "defaultPeriod":900
-    },
-    {
-      "displayName":"Total VOC",
-      "sensorType":"gas-resistance",
-      "defaultPeriod":900
-    }
-  ]
+  "subcomponents": [ "ambient-temp", "humidity", "pressure", "altitude", "gas-resistance" ]
 }

--- a/components/i2c/dps310/definition.json
+++ b/components/i2c/dps310/definition.json
@@ -1,16 +1,5 @@
 {
   "displayName": "DPS310",
   "i2cAddresses": [ "0x76", "0x77" ],
-  "subcomponents": [
-    {
-      "displayName": "Temperature Sensor",
-      "sensorType": "ambient-temp",
-      "defaultPeriod": 900
-    },
-    {
-      "displayName": "Pressure Sensor",
-      "sensorType": "pressure",
-      "defaultPeriod": 900
-    }
-  ]
+  "subcomponents": [ "ambient-temp", "pressure" ]
 }

--- a/components/i2c/mcp9601/definition.json
+++ b/components/i2c/mcp9601/definition.json
@@ -1,16 +1,5 @@
 {
   "displayName": "MCP9601",
   "i2cAddresses": [ "0x60", "0x61", "0x62", "0x63", "0x64", "0x65", "0x66", "0x67" ],
-  "subcomponents": [
-    {
-      "displayName": "Thermocouple Temperature",
-      "sensorType": "object-temp",
-      "defaultPeriod": 900
-    },
-    {
-      "displayName": "Ambient Temperature",
-      "sensorType": "ambient-temp",
-      "defaultPeriod": 900
-    }
-  ]
+  "subcomponents": [ "object-temp", "ambient-temp" ]
 }

--- a/components/i2c/mcp9808/definition.json
+++ b/components/i2c/mcp9808/definition.json
@@ -1,11 +1,5 @@
 {
   "displayName": "MCP9808",
   "i2cAddresses": [ "0x18", "0x19", "0x1A", "0x1C" ],
-  "subcomponents": [
-    {
-      "displayName": "Temperature Sensor",
-      "sensorType": "ambient-temp",
-      "defaultPeriod": 900
-    }
-  ]
+  "subcomponents": [ "ambient-temp" ]
 }

--- a/components/i2c/scd30/definition.json
+++ b/components/i2c/scd30/definition.json
@@ -1,20 +1,5 @@
 {
 	"displayName": "SCD30",
 	"i2cAddresses": ["0x61"],
-	"subcomponents": [{
-			"displayName": "Temperature",
-			"sensorType": "ambient-temp",
-			"defaultPeriod": 900
-		},
-		{
-			"displayName": "Relative Humidity",
-			"sensorType": "humidity",
-			"defaultPeriod": 900
-		},
-		{
-			"displayName": "CO2",
-			"sensorType": "co2",
-			"defaultPeriod": 900
-		}
-	]
+	"subcomponents": [ "ambient-temp", "humidity", "co2" ]
 }

--- a/components/i2c/scd40/definition.json
+++ b/components/i2c/scd40/definition.json
@@ -1,21 +1,5 @@
 {
 	"displayName": "SCD40",
 	"i2cAddresses": ["0x62"],
-	"subcomponents": [
-		{
-			"displayName": "Temperature",
-			"sensorType": "ambient-temp",
-			"defaultPeriod": 900
-		},
-		{
-			"displayName": "Relative Humidity",
-			"sensorType": "humidity",
-			"defaultPeriod": 900
-		},
-		{
-			"displayName": "CO2",
-			"sensorType": "co2",
-			"defaultPeriod": 900
-		}
-	]
+	"subcomponents": [ "ambient-temp", "humidity", "co2" ]
 }

--- a/components/i2c/schema.json
+++ b/components/i2c/schema.json
@@ -4,7 +4,8 @@
   "type": "object",
   "$defs": {
     "subcomponent": {
-      "type": "object",
+      "type": ["string", "object"],
+      "pattern": "^(unspecified|accelerometer|magnetic-field|orientation|gyroscope|light|pressure|proximity|gravity|acceleration|rotation|humidity|ambient-temp|object-temp|voltage|current|color|raw|pm10-std|pm25-std|pm100-std|pm10-env|pm25-env|pm100-env|co2|gas-resistance|altitude|lux|eco2)$",
       "required": [ "displayName", "sensorType" ],
       "properties": {
         "displayName": {
@@ -22,7 +23,7 @@
         "sensorType": {
           "description": "One of the supported I2C sensor type strings (found in README).",
           "type": "string",
-          "pattern": "^(unspecified|accelerometer|magnetic-field|orientation|gyroscope|light|pressure|proximity|gravity|acceleration|rotation|humidity|ambient-temp|object-temp|voltage|current|color|raw|pm10-std|pm25-std|pm100-std|pm10-env|pm25-env|pm100-env|co2|gas-resistance|altitude)$"
+          "pattern": "^(unspecified|accelerometer|magnetic-field|orientation|gyroscope|light|pressure|proximity|gravity|acceleration|rotation|humidity|ambient-temp|object-temp|voltage|current|color|raw|pm10-std|pm25-std|pm100-std|pm10-env|pm25-env|pm100-env|co2|gas-resistance|altitude|lux|eco2)$"
         },
         "defaultPeriod": {
           "description": "What period to the form should default to for this sensor.",

--- a/components/i2c/tsl2591/definition.json
+++ b/components/i2c/tsl2591/definition.json
@@ -1,11 +1,5 @@
 {
   "displayName": "TSL2591",
   "i2cAddresses": [ "0x29", "0x39", "0x49" ],
-  "subcomponents": [
-    {
-      "displayName": "Light Sensor",
-      "sensorType": "light",
-      "defaultPeriod": 900
-    }
-  ]
+  "subcomponents": [ "light" ]
 }

--- a/components/pin/schema.json
+++ b/components/pin/schema.json
@@ -54,6 +54,18 @@
     "forceOnPeriod": {
       "description": "If true, the user must specify a period (won't be optional in the form).",
       "type": "boolean"
+    },
+    "visualization": {
+      "description": "Specifies which visual component to use in the WipperSnapper interface and how to configure it",
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "description": "What component visualization to use to display the values from this sensor.",
+          "type": "string",
+          "pattern": "^(switch|button|slider)$"
+        }
+      }
     }
   }
 }

--- a/components/sensors.json
+++ b/components/sensors.json
@@ -1,0 +1,114 @@
+{
+  "accelerometer": {
+    "displayName": "Accelerometer",
+    "defaultPeriod": 900
+  },
+  "magnetic-field": {
+    "displayName": "Magnetic Field Sensor",
+    "defaultPeriod": 900
+  },
+  "orientation": {
+    "displayName": "Orientation Sensor",
+    "defaultPeriod": 900
+  },
+  "gyroscope": {
+    "displayName": "Gyroscope",
+    "defaultPeriod": 900
+  },
+  "light": {
+    "displayName": "Light Sensor",
+    "defaultPeriod": 900
+  },
+  "pressure": {
+    "displayName": "Pressure Sensor",
+    "defaultPeriod": 900
+  },
+  "proximity": {
+    "displayName": "Proximity Sensor",
+    "defaultPeriod": 900
+  },
+  "gravity": {
+    "displayName": "Gravity Sensor",
+    "defaultPeriod": 900
+  },
+  "acceleration": {
+    "displayName": "Acceleration Sensor",
+    "defaultPeriod": 900
+  },
+  "rotation": {
+    "displayName": "Rotation Sensor",
+    "defaultPeriod": 900
+  },
+  "humidity": {
+    "displayName": "Humidity Sensor",
+    "defaultPeriod": 900
+  },
+  "ambient-temp": {
+    "displayName": "Temperature Sensor",
+    "defaultPeriod": 900
+  },
+  "object-temp": {
+    "displayName": "Thermocouple Temperature",
+    "defaultPeriod": 900
+  },
+  "voltage": {
+    "displayName": "Voltage Sensor",
+    "defaultPeriod": 900
+  },
+  "current": {
+    "displayName": "Current",
+    "defaultPeriod": 900
+  },
+  "color": {
+    "displayName": "Color",
+    "defaultPeriod": 900
+  },
+  "raw": {
+    "displayName": "Raw Data",
+    "defaultPeriod": 900
+  },
+  "pm10-std": {
+    "displayName": "PM10 Standard",
+    "defaultPeriod": 900
+  },
+  "pm25-std": {
+    "displayName": "PM25 Standard",
+    "defaultPeriod": 900
+  },
+  "pm100-std": {
+    "displayName": "PM10 Standard",
+    "defaultPeriod": 900
+  },
+  "pm10-env": {
+    "displayName": "PM10  Environmental",
+    "defaultPeriod": 900
+  },
+  "pm25-env": {
+    "displayName": "PM25 Environmental",
+    "defaultPeriod": 900
+  },
+  "pm100-env": {
+    "displayName": "PM100 Environmental",
+    "defaultPeriod": 900
+  },
+  "co2": {
+    "displayName": "CO2",
+    "defaultPeriod": 900
+  },
+  "gas-resistance": {
+    "displayName": "Total VOC",
+    "defaultPeriod" :900
+  },
+  "altitude": {
+    "displayName": "Altitude (Relative)",
+    "defaultPeriod": 900
+  },
+  "lux": {
+    "displayName": "Light Sensor (Lux)",
+    "defaultPeriod": 900
+  },
+  "eco2": {
+    "displayName": "Estimated C02",
+    "defaultPeriod": 900
+  }
+}


### PR DESCRIPTION
Simplifies what is required in i2c `definition.json` files. From: 
```json
{
  ...
  "subcomponents": [
    {
      "displayName": "Temperature Sensor",
      "sensorType": "ambient-temp",
      "defaultPeriod": 900
    },
    {
      "displayName": "Humidity Sensor",
      "sensorType": "humidity",
      "defaultPeriod": 900
    }
  ]
}
```
...to:
```json
  ...
  "subcomponents": [ "ambient-temp", "humidity" ]
```

Using a separate `sensors.json` file to define the defaults for a given sensor type, like:
```json
{
  ...
  "humidity": {
    "displayName": "Humidity Sensor",
    "defaultPeriod": 900
  },
  "ambient-temp": {
    "displayName": "Temperature Sensor",
    "defaultPeriod": 900
  }
  ...
}
```
...soon to include the "visualization" key for specifying the how they look in WipperSnapper.

Components could still define the full object if they want to override defaults.