### PR TITLE
SEN55: Update published to true, add working models

### DIFF
--- a/components/i2c/sen5x/definition.json
+++ b/components/i2c/sen5x/definition.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "SEN55/54/50",
+  "displayName": "SEN5x",
   "published": true,
   "i2cAddresses": ["0x69"],
   "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "humidity", "pm10-std", "pm25-std", "pm100-std", "voc-index", "nox-index"]

--- a/components/i2c/sen5x/definition.json
+++ b/components/i2c/sen5x/definition.json
@@ -1,6 +1,6 @@
 {
-  "displayName": "SEN55",
-  "published": false,
+  "displayName": "SEN55/54/50",
+  "published": true,
   "i2cAddresses": ["0x69"],
   "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "humidity", "pm10-std", "pm25-std", "pm100-std", "voc-index", "nox-index"]
 }


### PR DESCRIPTION
I've tested the code with the other models of the SEN5x series, they all work, and any unsupported metrics are returned as Nan as expected. The user is expected to know what they have purchased, i.e. to expect unsupported metrics if not purchased. As and when adafruit start selling one of the series then it maybe worth separating into 3 different components and turning off the unsupported metrics while utilising the same driver.

I've tested using the 3v-5v boost breakout [5649](https://www.adafruit.com/product/5649) which is fantastic.

Stuck a learn guide up too, although far to scrappy:
https://learn.adafruit.com/u/tyeth/wippersnapper-sensirion-sen55-particulate-voc-nox-sensor