### PR TITLE
Updated stemma soil sensor I2C addresses

### DIFF
--- a/components/i2c/stemma_soil/definition.json
+++ b/components/i2c/stemma_soil/definition.json
@@ -1,7 +1,7 @@
 {
   "displayName": "STEMMA Soil Sensor",
   "published": true,
-  "i2cAddresses": [ "0x36"],
+  "i2cAddresses": [ "0x36","0x37","0x38","0x39"],
   "subcomponents": [
     "ambient-temp",
     "ambient-temp-fahrenheit",


### PR DESCRIPTION
Added missing 3 I2C addresses per AD0 and AD1 jumpers. Ref: https://learn.adafruit.com/adafruit-stemma-soil-sensor-i2c-capacitive-moisture-sensor/pinouts