### PR TITLE
Rename SHT30 packages

### DIFF
--- a/components/i2c/sht30_shell/definition.json
+++ b/components/i2c/sht30_shell/definition.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "SHT30 + Shell",
+  "displayName": "Enclosed SHT30",
   "published": false,
   "i2cAddresses": [ "0x44" ],
   "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "humidity" ]

--- a/components/i2c/sht30_weatherproof/definition.json
+++ b/components/i2c/sht30_weatherproof/definition.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "SHT30 Weatherproof Mesh",
+  "displayName": "Weatherproof SHT30",
   "published": false,
   "i2cAddresses": [ "0x44" ],
   "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "humidity" ]


### PR DESCRIPTION
Shorten the names of SHT30 packaged variants

Renaming "sht30+shell" to "Enclosed SHT30", and "SHT30 Weatherproof Mesh" to "Weatherproof SHT30"
![image](https://github.com/adafruit/Wippersnapper_Components/assets/6692083/3c4460f1-27bd-4ffa-b4cb-ec533aa8988a)
