### PR TITLE
Fix: Correct Particulate Matter displaynames

### DIFF
--- a/components/sensors.json
+++ b/components/sensors.json
@@ -76,27 +76,27 @@
     "defaultPeriod": 900
   },
   "pm10-std": {
-    "displayName": "PM10 Standard",
+    "displayName": "PM1.0 Standard",
     "defaultPeriod": 900
   },
   "pm25-std": {
-    "displayName": "PM25 Standard",
+    "displayName": "PM2.5 Standard",
     "defaultPeriod": 900
   },
   "pm100-std": {
-    "displayName": "PM100 Standard",
+    "displayName": "PM10.0 Standard",
     "defaultPeriod": 900
   },
   "pm10-env": {
-    "displayName": "PM10  Environmental",
+    "displayName": "PM1.0  Environmental",
     "defaultPeriod": 900
   },
   "pm25-env": {
-    "displayName": "PM25 Environmental",
+    "displayName": "PM2.5 Environmental",
     "defaultPeriod": 900
   },
   "pm100-env": {
-    "displayName": "PM100 Environmental",
+    "displayName": "PM10.0 Environmental",
     "defaultPeriod": 900
   },
   "co2": {


### PR DESCRIPTION
The particulate metrics are meant to represent size 1.0micron, 2.5, 10.0
They are off by a factor of 10 (an artifact of the field naming)