### PR TITLE
Modify True Lux sensors to use "lux" sensor type

### DIFF
--- a/components/i2c/bh1750/definition.json
+++ b/components/i2c/bh1750/definition.json
@@ -2,5 +2,5 @@
   "displayName": "BH1750",
   "published": true,
   "i2cAddresses": [ "0x23", "0x5C" ],
-  "subcomponents": [ "light" ]
+  "subcomponents": [ "lux" ]
 }

--- a/components/i2c/tsl2591/definition.json
+++ b/components/i2c/tsl2591/definition.json
@@ -2,5 +2,5 @@
   "displayName": "TSL2591",
   "published": true,
   "i2cAddresses": [ "0x29", "0x39", "0x49" ],
-  "subcomponents": [ "light" ]
+  "subcomponents": [ "lux" ]
 }

--- a/components/i2c/vcnl4040/definition.json
+++ b/components/i2c/vcnl4040/definition.json
@@ -3,7 +3,7 @@
   "published": false,
   "i2cAddresses": [ "0x60" ],
   "subcomponents": [
-    "light",
+    "lux",
     {
       "displayName": "Raw Proximity",
       "sensorType": "raw"

--- a/components/i2c/veml7700/definition.json
+++ b/components/i2c/veml7700/definition.json
@@ -2,5 +2,5 @@
   "displayName": "VEML7700",
   "published": true,
   "i2cAddresses": [ "0x10" ],
-  "subcomponents": [ "light" ]
+  "subcomponents": [ "lux" ]
 }


### PR DESCRIPTION
Noticed while testing the VCNL4040 that the "light" sensor type has no units. The official SI unit of lux is only displayed for the "lux" sensor type.