### PR TITLE
Add VL53L1X VL53L4CD/X VL6180X

### DIFF
--- a/components/i2c/vl53l4cx/definition.json
+++ b/components/i2c/vl53l4cx/definition.json
@@ -1,0 +1,15 @@
+{
+  "displayName": "VL53L4CX",
+  "published": false,
+  "vendor": "STMicroelectronics",
+  "productURL": "https://www.adafruit.com/product/5425",
+  "documentationURL": "https://learn.adafruit.com/adafruit-vl53l4cx-time-of-flight-distance-sensor",
+  "i2cAddresses": [ "0x29" ],
+  "subcomponents": [
+    {
+      "displayName": "ToF Sensor",
+      "sensorType": "proximity",
+      "defaultPeriod": 30
+    }
+  ]
+}


### PR DESCRIPTION
~~This updates the addresses available for the VL53L0X.~~

~~Also adds new unpublished definitions for:
VL53L1X
VL53L4CD
VL53L4CX
VL6180X~~

Breaking into tasks
- [x] VL53L1X
- [x] VL53L4CD
- [x] VL53L4CX
- [x] VL6180X