### PR TITLE
PM1006 - Reduce amount of readings

### DIFF
--- a/components/uart/pm1006/definition.json
+++ b/components/uart/pm1006/definition.json
@@ -4,7 +4,7 @@
   "productURL": "https://www.ikea.com/us/en/p/vindriktning-air-quality-sensor-60515911/",
   "documentationURL": "https://learn.adafruit.com/ikea-vindriktning-hack-with-qt-py-esp32-s3-and-adafruit-io",
   "published": false,
-  "subcomponents": ["pm10-std", "pm25-std", "pm100-std", "pm10-env", "pm25-env", "pm100-env"],
+  "subcomponents": ["pm25-env"],
   "baudRate": 9600,
   "inverted": false
 }


### PR DESCRIPTION
PM1006 only reads PM25_env, this PR reduces the amount of readings it can be configured to take