### PR TITLE
Update rotary encoder definition.json

### DIFF
--- a/components/i2c/rotary_encoder/definition.json
+++ b/components/i2c/rotary_encoder/definition.json
@@ -9,10 +9,6 @@
 		{
 			"displayName": "Rotary Encoder Value",
 			"sensorType": "raw"
-		},
-		{
-			"displayName": "Rotary Encoder Button",
-			"sensorType": "raw"
 		}
 	]
 }


### PR DESCRIPTION
After discussion it was realised that there cannot currently be two of the same subcomponent type in one component definition.

There will be a future resolution before this component is published, but this allows work on the encoder to continue in parallel.