### PR TITLE
Add all the supported MCP9808 I2C addresses

### DIFF
--- a/components/i2c/mcp9808/definition.json
+++ b/components/i2c/mcp9808/definition.json
@@ -4,6 +4,6 @@
   "productURL": "https://www.adafruit.com/product/1782",
   "documentationURL": "https://learn.adafruit.com/adafruit-mcp9808-precision-i2c-temperature-sensor-guide/overview",
   "published": true,
-  "i2cAddresses": [ "0x18", "0x19", "0x1A", "0x1C" ],
+  "i2cAddresses": [ "0x18", "0x19", "0x1A", "0x1B", "0x1C", "0x1D", "0x1E", "0x1F"],
   "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit" ]
 }


### PR DESCRIPTION
While updating the guide page I calculated the possible addresses, then tested they show on real device.