### PR TITLE
Publish AHT21 once firmware released

### DIFF
--- a/components/i2c/aht21/definition.json
+++ b/components/i2c/aht21/definition.json
@@ -1,7 +1,8 @@
 {
     "vendor": "ASAIR",
     "documentationURL": "http://www.aosong.com/en/products-60.html",
-    "displayName": "aht21",
+    "displayName": "AHT21",
+    "published": true,
     "i2cAddresses": [ "0x38"],
     "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "humidity"]
 }


### PR DESCRIPTION
Blocked by released version of firmware including https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/pull/660