### PR TITLE
I2C Output - Add Alt. I2C address for SSD1306

### DIFF
--- a/components/i2c_output/oled128x32default/definition.json
+++ b/components/i2c_output/oled128x32default/definition.json
@@ -5,7 +5,7 @@
   "productURL": "https://www.adafruit.com/product/4440",
   "documentationURL": "https://learn.adafruit.com/monochrome-oled-breakouts",
   "description": "Monochrome 128x32 OLED graphic display with the default font size.",
-  "i2cAddresses": [ "0x3C" ],
+  "i2cAddresses": [ "0x3C", "0x3D" ],
   "outputType": "OLED",
   "oledWidth": 128,
   "oledHeight": 32,

--- a/components/i2c_output/oled128x32large/definition.json
+++ b/components/i2c_output/oled128x32large/definition.json
@@ -5,7 +5,7 @@
   "productURL": "https://www.adafruit.com/product/4440",
   "documentationURL": "https://learn.adafruit.com/monochrome-oled-breakouts",
   "description": "Monochrome 128x32 I2C OLED Display with a larger font size",
-  "i2cAddresses": [ "0x3C" ],
+  "i2cAddresses": [ "0x3C", "0x3D" ],
   "outputType": "OLED",
   "oledWidth": 128,
   "oledHeight": 32,

--- a/components/i2c_output/oled128x64default/definition.json
+++ b/components/i2c_output/oled128x64default/definition.json
@@ -5,7 +5,7 @@
   "productURL": "https://www.adafruit.com/product/938",
   "documentationURL": "https://learn.adafruit.com/monochrome-oled-breakouts",
   "description": "Monochrome 128x64 I2C OLED Display with the default font size.",
-  "i2cAddresses": [ "0x3D" ],
+  "i2cAddresses": [ "0x3C", "0x3D" ],
   "outputType": "OLED",
   "oledWidth": 128,
   "oledHeight": 64,

--- a/components/i2c_output/oled128x64large/definition.json
+++ b/components/i2c_output/oled128x64large/definition.json
@@ -5,7 +5,7 @@
   "productURL": "https://www.adafruit.com/product/938",
   "documentationURL": "https://learn.adafruit.com/monochrome-oled-breakouts",
   "description": "Monochrome 128x64 I2C OLED Display with a larger font size.",
-  "i2cAddresses": [ "0x3D" ],
+  "i2cAddresses": [ "0x3C", "0x3D" ],
   "outputType": "OLED",
   "oledWidth": 128,
   "oledHeight": 64,


### PR DESCRIPTION
Expanded I2C address list for SSD1306 displays to include alternative `0x3C` address

Related Post: https://forums.adafruit.com/viewtopic.php?t=219071