### PR TITLE
Add INA228 (unpublished)

### DIFF
--- a/components/i2c/ina228/definition.json
+++ b/components/i2c/ina228/definition.json
@@ -1,0 +1,10 @@
+{
+  "displayName": "INA228",
+  "vendor": "Texas Instruments",
+  "productURL": "https://www.adafruit.com/product/5832",
+  "documentationURL": "https://learn.adafruit.com/adafruit-ina228-i2c-power-monitor",
+  "description": "85V, 20-bit, ultra-high-precision power monitor (max 10A, 0.05% gain error)",
+  "published": false,
+  "i2cAddresses": [ "0x40", "0x41", "0x44", "0x45" ],
+  "subcomponents": [ "voltage", "current" ]
+}


### PR DESCRIPTION
This pull request adds a new component definition for the INA228 power monitor. The definition includes key metadata and configuration details for integrating the device.

Component definition addition:

* Added `components/i2c/ina228/definition.json` to define the INA228 power monitor, including display name, vendor, product and documentation URLs, description, supported I2C addresses, and subcomponents.

https://github.com/adafruit/Wippersnapper_Components/blob/d9c10887f9ba01d175d9255c4d41a9c42a2d84eb/components/i2c/ina228/definition.json#L2-L9