### PR TITLE
fix(gps): remove gps example sub-properties

### DIFF
--- a/components/i2c/gps_sfe_ubx/definition.json
+++ b/components/i2c/gps_sfe_ubx/definition.json
@@ -8,10 +8,6 @@
   "i2cAddresses": [ "0x42" ],
   "isGps": true,
   "gps": {
-    "period": 1000,
-    "commands_ubxes": [
-      "JgAABgEIBgAxnyk=",
-      "JgAABgEIOAAwTBI="
-    ]
+    "period": 1000
   }
 }

--- a/components/uart/ultimate_gps/definition.json
+++ b/components/uart/ultimate_gps/definition.json
@@ -13,10 +13,6 @@
   "invert_sw_serial": false,
   "deviceType": "gps",
   "gps": {
-    "period": 1000,
-    "commands_pmtks": [
-      "PMTK314,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
-      "PMTK220,1000"
-    ]
+    "period": 1000
   }
 }


### PR DESCRIPTION
I asked for these fields to be used in a component definition, so that I could test them being fed through the tool, and reach the firmware as intended.

They are example entries and not valid / needed, so being removed now that testing is complete and the bugs in tool fixed.