### PR TITLE
add(bmp581): datasheet docs for now

### DIFF
--- a/components/i2c/bmp580/definition.json
+++ b/components/i2c/bmp580/definition.json
@@ -1,0 +1,9 @@
+{
+  "displayName": "BMP580",
+  "vendor": "Bosch",
+  "productURL": "https://www.adafruit.com/product/6411",
+  "documentationURL": "https://cdn-shop.adafruit.com/product-files/6411/BMP580.pdf",
+  "published": false,
+  "i2cAddresses": [ "0x47", "0x46" ],
+  "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "pressure", "altitude" ]
+}

--- a/components/i2c/bmp581/definition.json
+++ b/components/i2c/bmp581/definition.json
@@ -1,0 +1,9 @@
+{
+  "displayName": "BMP581",
+  "vendor": "Bosch",
+  "productURL": "https://www.adafruit.com/product/6407",
+  "documentationURL": "https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp581-ds004.pdf",
+  "published": false,
+  "i2cAddresses": [ "0x47", "0x46" ],
+  "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "pressure", "altitude" ]
+}

--- a/components/i2c/bmp585/definition.json
+++ b/components/i2c/bmp585/definition.json
@@ -1,0 +1,9 @@
+{
+  "displayName": "BMP585",
+  "vendor": "Bosch",
+  "productURL": "https://www.adafruit.com/product/6413",
+  "documentationURL": "https://cdn-shop.adafruit.com/product-files/6413/bst-bmp585-ds003.pdf",
+  "published": false,
+  "i2cAddresses": [ "0x47", "0x46" ],
+  "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "pressure", "altitude" ]
+}


### PR DESCRIPTION
Adds the Bosch BMP581 pressure sensor, along with the rest of the family (BMP580/BMP585)

Linked to https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/pull/805