### PR TITLE
Add 2.9" flexible UC8151D(ILI0373?), 3.7" UC8253, 4.2" SSD1683, 5.83" UC8179 E-Inks, and 1.5" + 1.12" 128x128 OLEDs

### DIFF
--- a/components/display/eink-29-flexible-monochrome-296x128/definition.json
+++ b/components/display/eink-29-flexible-monochrome-296x128/definition.json
@@ -14,7 +14,8 @@
         "epdConfig": {
             "mode": "mono",
             "width": 296,
-            "height": 128
+            "height": 128,
+            "textSize": 3
         }
     }
 }

--- a/components/display/eink-29-flexible-monochrome-296x128/definition.json
+++ b/components/display/eink-29-flexible-monochrome-296x128/definition.json
@@ -1,0 +1,20 @@
+{
+    "displayName": "2.9\" Flexible Monochrome eInk (UC8151D)",
+    "vendor": "Adafruit",
+    "productURL": "https://www.adafruit.com/product/4262",
+    "documentationURL": "https://learn.adafruit.com/adafruit-eink-display-breakouts",
+    "published": true,
+    "description": "2.9\" Flexible 296x128 Monochrome eInk / ePaper Display with UC8151D Chipset.",
+    "displayType": {
+        "type": "epd",
+        "driver": "epd_uc8151d",
+        "spiEpd": {
+            "bus": 0
+        },
+        "epdConfig": {
+            "mode": "monochrome",
+            "width": 296,
+            "height": 128
+        }
+    }
+}

--- a/components/display/eink-29-flexible-monochrome-296x128/definition.json
+++ b/components/display/eink-29-flexible-monochrome-296x128/definition.json
@@ -12,7 +12,7 @@
             "bus": 0
         },
         "epdConfig": {
-            "mode": "monochrome",
+            "mode": "mono",
             "width": 296,
             "height": 128
         }

--- a/components/display/eink-37-monochrome-416x240/definition.json
+++ b/components/display/eink-37-monochrome-416x240/definition.json
@@ -12,7 +12,7 @@
             "bus": 0
         },
         "epdConfig": {
-            "mode": "monochrome",
+            "mode": "mono",
             "width": 416,
             "height": 240
         }

--- a/components/display/eink-37-monochrome-416x240/definition.json
+++ b/components/display/eink-37-monochrome-416x240/definition.json
@@ -14,7 +14,8 @@
         "epdConfig": {
             "mode": "mono",
             "width": 416,
-            "height": 240
+            "height": 240,
+            "textSize": 3
         }
     }
 }

--- a/components/display/eink-37-monochrome-416x240/definition.json
+++ b/components/display/eink-37-monochrome-416x240/definition.json
@@ -1,0 +1,20 @@
+{
+    "displayName": "3.7\" Monochrome eInk (UC8253/ILI0373)",
+    "vendor": "Adafruit",
+    "productURL": "https://www.adafruit.com/product/6395",
+    "documentationURL": "https://learn.adafruit.com/adafruit-eink-display-breakouts",
+    "published": true,
+    "description": "3.7\" 416x240 Monochrome Black/White eInk / ePaper - Bare Display with UC8253 Chipset.",
+    "displayType": {
+        "type": "epd",
+        "driver": "epd_uc8253",
+        "spiEpd": {
+            "bus": 0
+        },
+        "epdConfig": {
+            "mode": "monochrome",
+            "width": 416,
+            "height": 240
+        }
+    }
+}

--- a/components/display/eink-42-grayscale-300x400/definition.json
+++ b/components/display/eink-42-grayscale-300x400/definition.json
@@ -14,7 +14,8 @@
         "epdConfig": {
             "mode": "grayscale4",
             "width": 400,
-            "height": 300
+            "height": 300,
+            "textSize": 3
         }
     }
 }

--- a/components/display/eink-42-grayscale-300x400/definition.json
+++ b/components/display/eink-42-grayscale-300x400/definition.json
@@ -1,0 +1,20 @@
+{
+    "displayName": "4.2\" Grayscale eInk (SSD1683)",
+    "vendor": "Adafruit",
+    "productURL": "https://www.adafruit.com/product/6381",
+    "documentationURL": "https://learn.adafruit.com/adafruit-eink-display-breakouts",
+    "published": true,
+    "description": "4.2\" 300x400 Monochrome or 4-Gray eInk / ePaper - Bare Display with SSD1683 driver.",
+    "displayType": {
+        "type": "epd",
+        "driver": "epd_ssd1683",
+        "spiEpd": {
+            "bus": 0
+        },
+        "epdConfig": {
+            "mode": "grayscale4",
+            "width": 400,
+            "height": 300
+        }
+    }
+}

--- a/components/display/eink-583-monochrome-648x480/definition.json
+++ b/components/display/eink-583-monochrome-648x480/definition.json
@@ -1,0 +1,20 @@
+{
+    "displayName": "5.83\" Monochrome eInk (UC8179)",
+    "vendor": "Adafruit",
+    "productURL": "https://www.adafruit.com/product/6397",
+    "documentationURL": "https://learn.adafruit.com/adafruit-eink-display-breakouts",
+    "published": true,
+    "description": "5.83\" 648x480 Monochrome Black / White eInk / ePaper - Bare Display with UC8179 Chipset.",
+    "displayType": {
+        "type": "epd",
+        "driver": "epd_uc8179",
+        "spiEpd": {
+            "bus": 0
+        },
+        "epdConfig": {
+            "mode": "monochrome",
+            "width": 648,
+            "height": 480
+        }
+    }
+}

--- a/components/display/eink-583-monochrome-648x480/definition.json
+++ b/components/display/eink-583-monochrome-648x480/definition.json
@@ -12,7 +12,7 @@
             "bus": 0
         },
         "epdConfig": {
-            "mode": "monochrome",
+            "mode": "mono",
             "width": 648,
             "height": 480
         }

--- a/components/display/eink-583-monochrome-648x480/definition.json
+++ b/components/display/eink-583-monochrome-648x480/definition.json
@@ -14,7 +14,8 @@
         "epdConfig": {
             "mode": "mono",
             "width": 648,
-            "height": 480
+            "height": 480,
+            "textSize": 3
         }
     }
 }

--- a/components/i2c_output/oled128x128g15/definition.json
+++ b/components/i2c_output/oled128x128g15/definition.json
@@ -1,0 +1,13 @@
+{
+  "displayName": "128x128 Grayscale OLED 1.5in (Default Font)",
+  "published": true,
+  "vendor": "Adafruit",
+  "productURL": "https://www.adafruit.com/product/4741",
+  "documentationURL": "https://learn.adafruit.com/adafruit-grayscale-1-5-128x128-oled-display",
+  "description": "Grayscale 1.5\" 128x128 OLED LCD Display (SSD1327)",
+  "i2cAddresses": [ "0x3C", "0x3D" ],
+  "outputType": "OLED",
+  "oledWidth": 128,
+  "oledHeight": 128,
+  "textSize": "SZ_DEFAULT"
+}

--- a/components/i2c_output/oled128x128g15lg/definition.json
+++ b/components/i2c_output/oled128x128g15lg/definition.json
@@ -1,0 +1,13 @@
+{
+  "displayName": "128x128 Grayscale OLED 1.5in (Large Font)",
+  "published": true,
+  "vendor": "Adafruit",
+  "productURL": "https://www.adafruit.com/product/4741",
+  "documentationURL": "https://learn.adafruit.com/adafruit-grayscale-1-5-128x128-oled-display",
+  "description": "Grayscale 1.5\" 128x128 OLED LCD Display with a larger font size (SSD1327)",
+  "i2cAddresses": [ "0x3C", "0x3D" ],
+  "outputType": "OLED",
+  "oledWidth": 128,
+  "oledHeight": 128,
+  "textSize": "SZ_LARGE"
+}

--- a/components/i2c_output/oled128x128m112/definition.json
+++ b/components/i2c_output/oled128x128m112/definition.json
@@ -1,0 +1,13 @@
+{
+  "displayName": "128x128 Monochrome OLED 1.12in (Default Font)",
+  "published": true,
+  "vendor": "Adafruit",
+  "productURL": "https://www.adafruit.com/product/5297",
+  "documentationURL": "https://learn.adafruit.com/adafruit-monochrome-1-12-in-128x128-oled",
+  "description": "Monochrome 1.12\" 128x128 OLED LCD Display (SH1107)",
+  "i2cAddresses": [ "0x3C", "0x3D" ],
+  "outputType": "OLED",
+  "oledWidth": 128,
+  "oledHeight": 128,
+  "textSize": "SZ_DEFAULT"
+}

--- a/components/i2c_output/oled128x128m112lg/definition.json
+++ b/components/i2c_output/oled128x128m112lg/definition.json
@@ -1,0 +1,13 @@
+{
+  "displayName": "128x128 Monochrome OLED 1.12in (Large Font)",
+  "published": true,
+  "vendor": "Adafruit",
+  "productURL": "https://www.adafruit.com/product/5297",
+  "documentationURL": "https://learn.adafruit.com/adafruit-monochrome-1-12-in-128x128-oled",
+  "description": "Monochrome 1.12\" 128x128 OLED LCD Display with a larger font size (SH1107)",
+  "i2cAddresses": [ "0x3C", "0x3D" ],
+  "outputType": "OLED",
+  "oledWidth": 128,
+  "oledHeight": 128,
+  "textSize": "SZ_LARGE"
+}

--- a/components/i2c_output/oled128x32default/definition.json
+++ b/components/i2c_output/oled128x32default/definition.json
@@ -4,7 +4,7 @@
   "vendor": "Adafruit",
   "productURL": "https://www.adafruit.com/product/4440",
   "documentationURL": "https://learn.adafruit.com/monochrome-oled-breakouts",
-  "description": "Monochrome 128x32 OLED graphic display with the default font size. (SSD1306)",
+  "description": "Monochrome 128x32 OLED LCD display with the default font size. (SSD1306)",
   "i2cAddresses": [ "0x3C", "0x3D" ],
   "outputType": "OLED",
   "oledWidth": 128,

--- a/components/i2c_output/oled128x32large/definition.json
+++ b/components/i2c_output/oled128x32large/definition.json
@@ -4,7 +4,7 @@
   "vendor": "Adafruit",
   "productURL": "https://www.adafruit.com/product/4440",
   "documentationURL": "https://learn.adafruit.com/monochrome-oled-breakouts",
-  "description": "Monochrome 128x32 I2C OLED Display with a larger font size (SSD1306).",
+  "description": "Monochrome 128x32 OLED LCD Display with a larger font size (SSD1306).",
   "i2cAddresses": [ "0x3C", "0x3D" ],
   "outputType": "OLED",
   "oledWidth": 128,

--- a/components/i2c_output/oled128x64default/definition.json
+++ b/components/i2c_output/oled128x64default/definition.json
@@ -4,7 +4,7 @@
   "vendor": "Adafruit",
   "productURL": "https://www.adafruit.com/product/938",
   "documentationURL": "https://learn.adafruit.com/monochrome-oled-breakouts",
-  "description": "Monochrome 128x64 I2C OLED Display with the default font size (SSD1306)",
+  "description": "Monochrome 128x64 OLED LCD Display with the default font size (SSD1306)",
   "i2cAddresses": [ "0x3D", "0x3C" ],
   "outputType": "OLED",
   "oledWidth": 128,

--- a/components/i2c_output/oled128x64large/definition.json
+++ b/components/i2c_output/oled128x64large/definition.json
@@ -4,7 +4,7 @@
   "vendor": "Adafruit",
   "productURL": "https://www.adafruit.com/product/938",
   "documentationURL": "https://learn.adafruit.com/monochrome-oled-breakouts",
-  "description": "Monochrome 128x64 I2C OLED Display with a larger font size (SSD1306)",
+  "description": "Monochrome 128x64 OLED LCD Display with a larger font size (SSD1306)",
   "i2cAddresses": [ "0x3D", "0x3C" ],
   "outputType": "OLED",
   "oledWidth": 128,

--- a/components/i2c_output/oled64x32default/definition.json
+++ b/components/i2c_output/oled64x32default/definition.json
@@ -4,7 +4,7 @@
   "vendor": "Generic",
   "productURL": "https://www.digikey.com/en/products/detail/midas-displays/MDOB064032AV-WI/18088023",
   "documentationURL": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/docus/4808/MDOB064032AV-WI.pdf",
-  "description": "Monochrome 64x32 I2C OLED Display with the default font size. (SSD1306)",
+  "description": "Monochrome 64x32 OLED LCD Display with the default font size. (SSD1306)",
   "i2cAddresses": [ "0x3D", "0x3C" ],
   "outputType": "OLED",
   "oledWidth": 64,

--- a/components/i2c_output/oled64x32large/definition.json
+++ b/components/i2c_output/oled64x32large/definition.json
@@ -4,7 +4,7 @@
   "vendor": "Generic",
   "productURL": "https://www.digikey.com/en/products/detail/midas-displays/MDOB064032AV-WI/18088023",
   "documentationURL": "https://mm.digikey.com/Volume0/opasdata/d220001/medias/docus/4808/MDOB064032AV-WI.pdf",
-  "description": "Monochrome 64x32 I2C OLED Display with a larger font size. (SSD1306)",
+  "description": "Monochrome 64x32 OLED LCD Display with a larger font size. (SSD1306)",
   "i2cAddresses": [ "0x3D", "0x3C" ],
   "outputType": "OLED",
   "oledWidth": 64,


### PR DESCRIPTION
This pull request adds definitions for several new E-Ink and I2C OLED display components, and updates the descriptions for existing OLEDs for consistency.

@tyeth Verify that the correct drivers are being used for each new component!!!

### Component Checklist

- [ ] **4.2" Grayscale E-Ink Display (300x400)** ([Product 6381](https://www.adafruit.com/product/6381))
  - **Controller Chip**: `SSD1683`
  - **Required Driver**: `epd_ssd1683`
- [ ] **3.7" Monochrome E-Ink Display (416x240)** ([Product 6395](https://www.adafruit.com/product/6395))
  - **Controller Chip**: `UC8253` (ILI0373?)
  - **Required Driver**: `epd_uc8253`
- [ ] **5.83" Monochrome E-Ink Display (648x480)** ([Product 6397](https://www.adafruit.com/product/6397))
  - **Controller Chip**: `UC8179`
  - **Required Driver**: `epd_uc8179`
- [ ] **2.9" Flexible Monochrome E-Ink Display (296x128)** ([Product 4262](https://www.adafruit.com/product/4262))
  - **Controller Chip**: `UC8151D`
  - **Required Driver**: `epd_uc8151d`
- [ ] **1.5" Grayscale OLED (128x128)** ([Product 4741](https://www.adafruit.com/product/4741))
  - **Controller Chip**: `SSD1327`
- [ ] **1.12" Monochrome OLED (128x128)** ([Product 5297](https://www.adafruit.com/product/5297))
  - **Controller Chip**: `SH1107`
- [ ] **1.54" Tri-Color eInk / ePaper Display with SRAM - 200x200 with SSD1681 and EYESPI** ([Product 4868](https://www.adafruit.com/product/4868))
  - **Controller Chip**: `SSD1681`  - 


### Conflicting info, probably need extra definitions to cover the variants:
https://learn.adafruit.com/adafruit-2-9-eink-display-breakouts-and-featherwings#we-have-multiple-2-dot-9-epd-displays-3102306
> ## Breakouts and Flexibles
> We have a newer [296x128 Tri-Color display](https://www.adafruit.com/product/1028) with the UC8151D chipset, which has has black and red ink pixels and a white-ish background.
> The older tri-color breakout, which had the same Product ID, had the IL0373 chipset. This display is no longer offered.
> The [2.9" monochrome flexible display](https://www.adafruit.com/product/4262) has a resolution of 296x128 and is flexible. For this display, you will probably want to pick up an [e-Ink Breakout Friend](https://www.adafruit.com/product/4224) or [e-Ink Feather Friend](https://www.adafruit.com/product/4446). There is an [extension cable](https://www.adafruit.com/product/4230) available for this type of connection also.
> ## FeatherWings
> The newer [296x128 Tri-Color FeatherWing](https://www.adafruit.com/product/4778) with the SSD1675 chipset.
> The older tri-color FeatherWing with the IL0373 has the same display as the older breakout. This display is also no longer offered.
> The grayscale FeatherWing features 4 levels of grayscale. We have a [296x128 Grayscale FeatherWing](https://www.adafruit.com/product/4777).


### Second info block on arduino usage page:
https://learn.adafruit.com/adafruit-2-9-eink-display-breakouts-and-featherwings/arduino-usage#configure-display-type-and-size-3102374

> For the [2.9" 296x128 Monochrome Flexible Display](https://www.adafruit.com/product/4262), you will use the `ThinkInk_290_Mono_M06` display initializer.
> For the SSD1680 chipset version of the [2.9" 296x128 Tri-Color breakout](https://www.adafruit.com/product/1028) or [2.9" 296x128 Tri-Color FeatherWing](https://www.adafruit.com/product/4778), you will use the `ThinkInk_290_Tricolor_Z94` display initializer.
> For the UC8151D chipset version of the [2.9" 296x128 Tri-Color breakout](https://www.adafruit.com/product/1028), you will use the `ThinkInk_290_Tricolor_Z13` display initializer.
> For the IL0373 chipset version of the [2.9" 296x128 Tri-Color breakout](https://www.adafruit.com/product/1028) or [2.9" 296x128 Tri-Color FeatherWing](https://www.adafruit.com/product/4778), you will use the `ThinkInk_290_Tricolor_Z10` display initializer.
> For the [2.9" 296x128Grayscale breakout](https://www.adafruit.com/product/4086) , you will use the `ThinkInk_290_Grayscale4_T5` display initializer.



## 1.5" e-ink varies in res (old chip 154pix mono ILI0343?), new 200x200 SSD1681 mono/tri.
> For the [1.54" 200x200 Monochrome breakout](https://www.adafruit.com/product/4196) you will use ThinkInk_154_Mono_D27 display initializer.

>
>For the [1.54" 152x152 Tri-Color breakout](https://www.adafruit.com/product/3625), you will use the ThinkInk_154_Tricolor_Z17 display initializer.

>
> For the [1.54" 200x200 Tri-Color breakout](https://www.adafruit.com/product/4868), you will use the ThinkInk_154_Tricolor_Z90 display initializer.