### PR TITLE
Update product URL for HTU31D definition

### DIFF
--- a/components/i2c/htu31d/definition.json
+++ b/components/i2c/htu31d/definition.json
@@ -1,7 +1,7 @@
 {
   "displayName": "HTU31D",
   "vendor": "TE Connectivity",
-  "productURL": "https://www.adafruit.com/product/2857",
+  "productURL": "https://www.adafruit.com/product/4832",
   "documentationURL": "https://www.adafruit.com/product/4832",
   "published": true,
   "i2cAddresses": [ "0x40", "0x41" ],


### PR DESCRIPTION
While verifying something else I noticed the docs url wasn't a learn guide, but a prod url that doesn't match the product url field (was pointing at sht31d)