### PR TITLE
[Add] ADS 1x15 ADCs

### DIFF
--- a/components/expanders/ads1015/definition.json
+++ b/components/expanders/ads1015/definition.json
@@ -1,0 +1,15 @@
+{
+  "displayName": "ADS1015",
+  "description": "12-Bit ADC - 4 Channel.",
+  "published": true,
+  "vendor": "Adafruit Industries",
+  "productURL": "https://www.adafruit.com/product/1083",
+  "documentationURL": "https://learn.adafruit.com/adafruit-4-channel-adc-breakouts/",
+  "i2cAddresses": ["0x48", "0x49", "0x4A", "0x4B"],
+  "pins": [
+    {"displayName": "A0", "name": "0", "hasGPIO": false, "hasADC": true},
+    {"displayName": "A1", "name": "1", "hasGPIO": false, "hasADC": true},
+    {"displayName": "A2", "name": "2", "hasGPIO": false, "hasADC": true},
+    {"displayName": "A3", "name": "3", "hasGPIO": false, "hasADC": true}
+  ]
+}

--- a/components/expanders/ads1115/definition.json
+++ b/components/expanders/ads1115/definition.json
@@ -1,0 +1,15 @@
+{
+  "displayName": "ADS1115",
+  "description": "16-bit ADC - 4 Channel.",
+  "published": true,
+  "vendor": "Adafruit Industries",
+  "productURL": "https://www.adafruit.com/product/1085",
+  "documentationURL": "https://learn.adafruit.com/adafruit-4-channel-adc-breakouts/",
+  "i2cAddresses": ["0x48", "0x49", "0x4A", "0x4B"],
+  "pins": [
+    {"displayName": "A0", "name": "0", "hasGPIO": false, "hasADC": true},
+    {"displayName": "A1", "name": "1", "hasGPIO": false, "hasADC": true},
+    {"displayName": "A2", "name": "2", "hasGPIO": false, "hasADC": true},
+    {"displayName": "A3", "name": "3", "hasGPIO": false, "hasADC": true}
+  ]
+}


### PR DESCRIPTION
This pull request adds definitions for two new analog-to-digital converter (ADC) expanders from Adafruit:
- ADS1015
- ADS1115

These are considered expander components, so they are placed in the expanders/ folder for clarity. 

Related: https://github.com/adafruit/Wippersnapper_Protobuf/pull/193