### PR TITLE
Add 1.8" 128x160 ST7735R SPI TFT (PID 358)

### DIFF
--- a/components/display/tft/st7735r/128x160/adafruit-358/definition.json
+++ b/components/display/tft/st7735r/128x160/adafruit-358/definition.json
@@ -1,0 +1,22 @@
+{
+    "displayName": "1.8\" TFT LCD",
+    "vendor": "Adafruit",
+    "productURL": "https://www.adafruit.com/product/358",
+    "documentationURL": "https://learn.adafruit.com/1-8-tft-display",
+    "published": true,
+    "description": "Adafruit 1.8\" 128x160 Color TFT LCD display with MicroSD Card Breakout - ST7735R.",
+    "displayType": {
+        "type": "tft",
+        "driver": "ST7735R",
+        "panel": "1.8-128x160",
+        "spiTft": {
+            "bus": 0
+        },
+        "tftConfig": {
+            "width": 160,
+            "height": 128,
+            "rotation": 1,
+            "textSize": 2
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds component definition for Adafruit 1.8" 128x160 Color TFT (ST7735R), [PID 358](https://www.adafruit.com/product/358).
- Lands at `components/display/tft/st7735r/128x160/adafruit-358/definition.json`, following the post-#325 `adafruit-<PID>` leaf-folder convention.
- Values cross-checked against the [learn guide](https://learn.adafruit.com/1-8-tft-display) example: `ST7735R(display_bus, width=160, height=128, rotation=90, bgr=True)` — driver pins `bgr=True` host-side, so the def only carries width/height/rotation/textSize.

## Test plan
- [ ] Schema validates (`tft` displayType with `driver: ST7735R`, `panel: 1.8-128x160`).
- [ ] Matches host driver panel key in `Adafruit_WipperSnapper_Python/src/Adafruit_WipperSnapper_Python/display/drivers/st7735r.py` (`_PANEL_OFFSETS["1.8-128x160"]`).
- [ ] Matches the protomq demo (`tools/protomq/scripts/pi5-eyespi-beret-st7735r-demo.json`) — same driver / panel / 160×128 / rotation 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)