### PR TITLE
Add - Adafruit GPIO Expander Bonnet for Raspberry Pi

### DIFF
--- a/components/expanders/mcp23017_bonnet/definition.json
+++ b/components/expanders/mcp23017_bonnet/definition.json
@@ -1,0 +1,28 @@
+{
+  "displayName": "GPIO Expander Bonnet",
+  "description": "Adafruit GPIO Expander Bonnet for Raspberry Pi",
+  "published": true,
+  "vendor": "Adafruit Industries",
+  "productURL": "https://www.adafruit.com/product/4132",
+  "documentationURL": "https://learn.adafruit.com/gpio-expander-bonnet/",
+  "i2cAddresses": ["0x20", "0x21", "0x22", "0x23", "0x24", "0x25", "0x26", "0x27"],
+  "pins": [
+    {"displayName": "GPA0", "name": "0", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPA1", "name": "1", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPA2", "name": "2", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPA3", "name": "3", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPA4", "name": "4", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPA5", "name": "5", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPA6", "name": "6", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPA7", "name": "7", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPB0", "name": "8", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPB1", "name": "9", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPB2", "name": "10", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPB3", "name": "11", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPB4", "name": "12", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPB5", "name": "13", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPB6", "name": "14", "hasGPIO": true, "hasPullup": true},
+    {"displayName": "GPB7", "name": "15", "hasGPIO": true, "hasPullup": true}
+  ]
+}
+


### PR DESCRIPTION
Adding [Adafruit GPIO Expander Bonnet for Raspberry Pi](https://www.adafruit.com/product/4132). While we already support the mcp23017 as an Arduino breakout, the Bonnet adds different pin labeling. 