### PR TITLE
Add I2C sensor settings for backported v2 drivers

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,10 +39,17 @@ jobs:
         if:  ${{ !inputs.all_files }}
         id: list-changed-files
         run: |
-          # also fetch main to diff against
-          git fetch --depth=1 origin main
+          # Diff against the PR's target branch so we only consider files this
+          # PR actually changed: v2 PRs diff against v2; anything else (main, or
+          # workflow_dispatch with no base) diffs against main.
+          if [ "${{ github.base_ref }}" = "v2" ]; then
+            DIFF_BASE=v2
+          else
+            DIFF_BASE=main
+          fi
+          git fetch --depth=1 origin "$DIFF_BASE"
           # list Added, Copied, Modified, and Renamed files
-          ACMR_FILES=`git diff origin/main --name-only --diff-filter=ACMR | xargs`
+          ACMR_FILES=`git diff "origin/$DIFF_BASE" --name-only --diff-filter=ACMR | xargs`
           # GitHub Actions output ritual
           echo "all_changed_files=$ACMR_FILES" >> "$GITHUB_OUTPUT"
       - name: List All Component Files

--- a/components/i2c/as5600/definition.json
+++ b/components/i2c/as5600/definition.json
@@ -7,6 +7,33 @@
   "published": true,
   "i2cAddresses": [ "0x36" ],
   "settings": {
+    "z_position": {
+      "displayName": "Zero Position",
+      "description": "Start angle (raw 12-bit) for mapping a partial rotation.",
+      "type": "int",
+      "min": 0,
+      "max": 4095,
+      "default": 0,
+      "step": 1
+    },
+    "m_position": {
+      "displayName": "Max Position",
+      "description": "Stop angle (raw 12-bit) for mapping a partial rotation.",
+      "type": "int",
+      "min": 0,
+      "max": 4095,
+      "default": 4095,
+      "step": 1
+    },
+    "max_angle": {
+      "displayName": "Max Angle",
+      "description": "Maximum angle (raw 12-bit) mapped to the full output range.",
+      "type": "int",
+      "min": 0,
+      "max": 4095,
+      "default": 4095,
+      "step": 1
+    },
     "output_stage": {
       "displayName": "Output Stage",
       "default": 0,

--- a/components/i2c/as5600/definition.json
+++ b/components/i2c/as5600/definition.json
@@ -6,6 +6,42 @@
   "description": "Magnetic angle (0-359) I2C sensor with 0.1° precision and 0.4° accuracy",
   "published": true,
   "i2cAddresses": [ "0x36" ],
+  "settings": {
+    "output_stage": {
+      "displayName": "Output Stage",
+      "default": 0,
+      "options": ["Analog (full)", "Analog (reduced)", "Digital PWM"]
+    },
+    "power_mode": {
+      "displayName": "Power Mode",
+      "default": 0,
+      "options": ["Normal", "Low Power 1", "Low Power 2", "Low Power 3"]
+    },
+    "slow_filter": {
+      "displayName": "Slow Filter",
+      "default": 0,
+      "options": ["16x", "8x", "4x", "2x"]
+    },
+    "fast_filter_threshold": {
+      "displayName": "Fast Filter Threshold",
+      "default": 0,
+      "options": [
+        "Slow filter only",
+        "6 LSB",
+        "7 LSB",
+        "9 LSB",
+        "18 LSB",
+        "21 LSB",
+        "24 LSB",
+        "10 LSB"
+      ]
+    },
+    "hysteresis": {
+      "displayName": "Hysteresis",
+      "default": 0,
+      "options": ["Off", "1 LSB", "2 LSB", "3 LSB"]
+    }
+  },
   "subcomponents": [
     {
       "displayName": "Angle",

--- a/components/i2c/as7331/definition.json
+++ b/components/i2c/as7331/definition.json
@@ -6,5 +6,56 @@
   "documentationURL": "https://learn.adafruit.com/adafruit-as7331-uv-uva-uvb-uvc-sensor",
   "published": true,
   "i2cAddresses": ["0x74", "0x75", "0x76", "0x77"],
+  "settings": {
+    "gain": {
+      "displayName": "Gain",
+      "default": 9,
+      "options": [
+        "2048x",
+        "1024x",
+        "512x",
+        "256x",
+        "128x",
+        "64x",
+        "32x",
+        "16x",
+        "8x",
+        "4x",
+        "2x",
+        "1x"
+      ]
+    },
+    "integration_time": {
+      "displayName": "Integration Time",
+      "default": 6,
+      "options": [
+        "1 ms",
+        "2 ms",
+        "4 ms",
+        "8 ms",
+        "16 ms",
+        "32 ms",
+        "64 ms",
+        "128 ms",
+        "256 ms",
+        "512 ms",
+        "1024 ms",
+        "2048 ms",
+        "4096 ms",
+        "8192 ms",
+        "16384 ms"
+      ]
+    },
+    "mode": {
+      "displayName": "Measurement Mode",
+      "default": 0,
+      "options": ["Continuous", "Command", "Sync Start", "Sync Start/Stop"]
+    },
+    "clock_frequency": {
+      "displayName": "Clock Frequency",
+      "default": 0,
+      "options": ["1.024 MHz", "2.048 MHz", "4.096 MHz", "8.192 MHz"]
+    }
+  },
   "subcomponents": [{ "displayName": "UVB", "sensorType": "raw" }]
 }

--- a/components/i2c/bme280/definition.json
+++ b/components/i2c/bme280/definition.json
@@ -6,6 +6,16 @@
   "published": true,
   "i2cAddresses": ["0x77", "0x76"],
   "settings": {
+    "sea_level_pressure": {
+      "displayName": "Sea-Level Pressure",
+      "description": "Reference sea-level pressure for altitude calculation.",
+      "type": "float",
+      "min": 800,
+      "max": 1200,
+      "default": 1013.25,
+      "step": 0.25,
+      "unit": "hPa"
+    },
     "temp_oversampling": {
       "displayName": "Temperature Oversampling",
       "default": 0,

--- a/components/i2c/bme680/definition.json
+++ b/components/i2c/bme680/definition.json
@@ -6,6 +6,16 @@
   "published": true,
   "i2cAddresses": ["0x77", "0x76"],
   "settings": {
+    "sea_level_pressure": {
+      "displayName": "Sea-Level Pressure",
+      "description": "Reference sea-level pressure for altitude calculation.",
+      "type": "float",
+      "min": 800,
+      "max": 1200,
+      "default": 1013.25,
+      "step": 0.25,
+      "unit": "hPa"
+    },
     "temp_oversampling": {
       "displayName": "Temperature Oversampling",
       "default": 3,

--- a/components/i2c/bme688/definition.json
+++ b/components/i2c/bme688/definition.json
@@ -6,6 +6,16 @@
   "published": true,
   "i2cAddresses": ["0x77", "0x76"],
   "settings": {
+    "sea_level_pressure": {
+      "displayName": "Sea-Level Pressure",
+      "description": "Reference sea-level pressure for altitude calculation.",
+      "type": "float",
+      "min": 800,
+      "max": 1200,
+      "default": 1013.25,
+      "step": 0.25,
+      "unit": "hPa"
+    },
     "temp_oversampling": {
       "displayName": "Temperature Oversampling",
       "default": 0,

--- a/components/i2c/bmp280/definition.json
+++ b/components/i2c/bmp280/definition.json
@@ -6,6 +6,16 @@
   "published": true,
   "i2cAddresses": ["0x77", "0x76"],
   "settings": {
+    "sea_level_pressure": {
+      "displayName": "Sea-Level Pressure",
+      "description": "Reference sea-level pressure for altitude calculation.",
+      "type": "float",
+      "min": 800,
+      "max": 1200,
+      "default": 1013.25,
+      "step": 0.25,
+      "unit": "hPa"
+    },
     "mode": {
       "displayName": "Mode",
       "description": "Sets the measurement mode of the sensor.",

--- a/components/i2c/bmp388/definition.json
+++ b/components/i2c/bmp388/definition.json
@@ -6,6 +6,16 @@
   "published": true,
   "i2cAddresses": ["0x77", "0x76"],
   "settings": {
+    "sea_level_pressure": {
+      "displayName": "Sea-Level Pressure",
+      "description": "Reference sea-level pressure for altitude calculation.",
+      "type": "float",
+      "min": 800,
+      "max": 1200,
+      "default": 1013.25,
+      "step": 0.25,
+      "unit": "hPa"
+    },
     "temp_oversampling": {
       "displayName": "Temperature Oversampling",
       "default": 3,

--- a/components/i2c/bmp390/definition.json
+++ b/components/i2c/bmp390/definition.json
@@ -6,6 +6,16 @@
   "published": true,
   "i2cAddresses": ["0x77", "0x76"],
   "settings": {
+    "sea_level_pressure": {
+      "displayName": "Sea-Level Pressure",
+      "description": "Reference sea-level pressure for altitude calculation.",
+      "type": "float",
+      "min": 800,
+      "max": 1200,
+      "default": 1013.25,
+      "step": 0.25,
+      "unit": "hPa"
+    },
     "temp_oversampling": {
       "displayName": "Temperature Oversampling",
       "default": 3,

--- a/components/i2c/bmp580/definition.json
+++ b/components/i2c/bmp580/definition.json
@@ -6,6 +6,16 @@
   "published": true,
   "i2cAddresses": ["0x47", "0x46"],
   "settings": {
+    "sea_level_pressure": {
+      "displayName": "Sea-Level Pressure",
+      "description": "Reference sea-level pressure for altitude calculation.",
+      "type": "float",
+      "min": 800,
+      "max": 1200,
+      "default": 1013.25,
+      "step": 0.25,
+      "unit": "hPa"
+    },
     "temp_oversampling": {
       "displayName": "Temperature Oversampling",
       "default": 0,

--- a/components/i2c/bmp581/definition.json
+++ b/components/i2c/bmp581/definition.json
@@ -6,6 +6,16 @@
   "published": true,
   "i2cAddresses": ["0x47", "0x46"],
   "settings": {
+    "sea_level_pressure": {
+      "displayName": "Sea-Level Pressure",
+      "description": "Reference sea-level pressure for altitude calculation.",
+      "type": "float",
+      "min": 800,
+      "max": 1200,
+      "default": 1013.25,
+      "step": 0.25,
+      "unit": "hPa"
+    },
     "temp_oversampling": {
       "displayName": "Temperature Oversampling",
       "default": 0,

--- a/components/i2c/bmp585/definition.json
+++ b/components/i2c/bmp585/definition.json
@@ -6,6 +6,16 @@
   "published": true,
   "i2cAddresses": ["0x47", "0x46"],
   "settings": {
+    "sea_level_pressure": {
+      "displayName": "Sea-Level Pressure",
+      "description": "Reference sea-level pressure for altitude calculation.",
+      "type": "float",
+      "min": 800,
+      "max": 1200,
+      "default": 1013.25,
+      "step": 0.25,
+      "unit": "hPa"
+    },
     "temp_oversampling": {
       "displayName": "Temperature Oversampling",
       "default": 0,

--- a/components/i2c/hdc302x/definition.json
+++ b/components/i2c/hdc302x/definition.json
@@ -7,12 +7,6 @@
   "published": true,
   "i2cAddresses": [ "0x44", "0x45", "0x46", "0x47" ],
   "settings": {
-    "mode": {
-      "displayName": "Measurement Precision",
-      "description": "Per-read conversion precision (LP0 = lowest noise).",
-      "default": 0,
-      "options": ["LP0 (lowest noise)", "LP1", "LP2", "LP3 (fastest)"]
-    },
     "heater": {
       "displayName": "Heater",
       "default": 0,

--- a/components/i2c/hdc302x/definition.json
+++ b/components/i2c/hdc302x/definition.json
@@ -6,5 +6,18 @@
   "description": "Precision temperature (±0.1°C typical) and humidity sensors (±0.5% typ). HDC3020 / HDC3021 / HDC3022",
   "published": true,
   "i2cAddresses": [ "0x44", "0x45", "0x46", "0x47" ],
+  "settings": {
+    "mode": {
+      "displayName": "Measurement Precision",
+      "description": "Per-read conversion precision (LP0 = lowest noise).",
+      "default": 0,
+      "options": ["LP0 (lowest noise)", "LP1", "LP2", "LP3 (fastest)"]
+    },
+    "heater": {
+      "displayName": "Heater",
+      "default": 0,
+      "options": ["Off", "Quarter Power", "Half Power", "Full Power"]
+    }
+  },
   "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "humidity" ]
 }

--- a/components/i2c/htu31d/definition.json
+++ b/components/i2c/htu31d/definition.json
@@ -5,5 +5,13 @@
   "documentationURL": "https://www.adafruit.com/product/4832",
   "published": true,
   "i2cAddresses": [ "0x40", "0x41" ],
+  "settings": {
+    "heater": {
+      "displayName": "Heater",
+      "description": "On-chip heater to clear condensation.",
+      "default": 0,
+      "options": ["Off", "On"]
+    }
+  },
   "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "humidity" ]
 }

--- a/components/i2c/ina228/definition.json
+++ b/components/i2c/ina228/definition.json
@@ -7,6 +7,26 @@
   "published": true,
   "i2cAddresses": [ "0x40", "0x41", "0x44", "0x45" ],
   "settings": {
+    "shunt_resistance": {
+      "displayName": "Shunt Resistance",
+      "description": "Resistance of the shunt fitted to the board.",
+      "type": "float",
+      "min": 0.001,
+      "max": 10,
+      "default": 0.015,
+      "step": 0.001,
+      "unit": "Ω"
+    },
+    "max_current": {
+      "displayName": "Max Expected Current",
+      "description": "Maximum expected current, used for calibration.",
+      "type": "float",
+      "min": 0.1,
+      "max": 20,
+      "default": 10,
+      "step": 0.1,
+      "unit": "A"
+    },
     "adc_range": {
       "displayName": "ADC Range",
       "description": "Shunt voltage measurement range.",

--- a/components/i2c/ina228/definition.json
+++ b/components/i2c/ina228/definition.json
@@ -6,5 +6,46 @@
   "description": "85V, 20-bit, ultra-high-precision power monitor (max 10A, 0.05% gain error)",
   "published": true,
   "i2cAddresses": [ "0x40", "0x41", "0x44", "0x45" ],
+  "settings": {
+    "adc_range": {
+      "displayName": "ADC Range",
+      "description": "Shunt voltage measurement range.",
+      "default": 0,
+      "options": ["±163.84 mV", "±40.96 mV"]
+    },
+    "averaged_samples": {
+      "displayName": "Averaged Samples",
+      "default": 2,
+      "options": ["1", "4", "16", "64", "128", "256", "512", "1024"]
+    },
+    "voltage_conversion_time": {
+      "displayName": "Voltage Conversion Time",
+      "default": 2,
+      "options": [
+        "50 µs",
+        "84 µs",
+        "150 µs",
+        "280 µs",
+        "540 µs",
+        "1052 µs",
+        "2074 µs",
+        "4120 µs"
+      ]
+    },
+    "current_conversion_time": {
+      "displayName": "Current Conversion Time",
+      "default": 3,
+      "options": [
+        "50 µs",
+        "84 µs",
+        "150 µs",
+        "280 µs",
+        "540 µs",
+        "1052 µs",
+        "2074 µs",
+        "4120 µs"
+      ]
+    }
+  },
   "subcomponents": [ "voltage", "current" ]
 }

--- a/components/i2c/ina237/definition.json
+++ b/components/i2c/ina237/definition.json
@@ -7,6 +7,26 @@
   "published": true,
   "i2cAddresses": [ "0x40", "0x41", "0x44", "0x45" ],
   "settings": {
+    "shunt_resistance": {
+      "displayName": "Shunt Resistance",
+      "description": "Resistance of the shunt fitted to the board.",
+      "type": "float",
+      "min": 0.001,
+      "max": 10,
+      "default": 0.015,
+      "step": 0.001,
+      "unit": "Ω"
+    },
+    "max_current": {
+      "displayName": "Max Expected Current",
+      "description": "Maximum expected current, used for calibration.",
+      "type": "float",
+      "min": 0.1,
+      "max": 20,
+      "default": 10,
+      "step": 0.1,
+      "unit": "A"
+    },
     "adc_range": {
       "displayName": "ADC Range",
       "description": "Shunt voltage measurement range.",

--- a/components/i2c/ina237/definition.json
+++ b/components/i2c/ina237/definition.json
@@ -6,5 +6,46 @@
   "description": "85V, 16-bit, good-precision power monitor (up to 10A, 0.3% gain error)",
   "published": true,
   "i2cAddresses": [ "0x40", "0x41", "0x44", "0x45" ],
+  "settings": {
+    "adc_range": {
+      "displayName": "ADC Range",
+      "description": "Shunt voltage measurement range.",
+      "default": 0,
+      "options": ["±163.84 mV", "±40.96 mV"]
+    },
+    "averaged_samples": {
+      "displayName": "Averaged Samples",
+      "default": 2,
+      "options": ["1", "4", "16", "64", "128", "256", "512", "1024"]
+    },
+    "voltage_conversion_time": {
+      "displayName": "Voltage Conversion Time",
+      "default": 2,
+      "options": [
+        "50 µs",
+        "84 µs",
+        "150 µs",
+        "280 µs",
+        "540 µs",
+        "1052 µs",
+        "2074 µs",
+        "4120 µs"
+      ]
+    },
+    "current_conversion_time": {
+      "displayName": "Current Conversion Time",
+      "default": 3,
+      "options": [
+        "50 µs",
+        "84 µs",
+        "150 µs",
+        "280 µs",
+        "540 µs",
+        "1052 µs",
+        "2074 µs",
+        "4120 µs"
+      ]
+    }
+  },
   "subcomponents": [ "voltage", "current" ]
 }

--- a/components/i2c/ina238/definition.json
+++ b/components/i2c/ina238/definition.json
@@ -7,6 +7,26 @@
   "published": true,
   "i2cAddresses": [ "0x40", "0x41", "0x44", "0x45" ],
   "settings": {
+    "shunt_resistance": {
+      "displayName": "Shunt Resistance",
+      "description": "Resistance of the shunt fitted to the board.",
+      "type": "float",
+      "min": 0.001,
+      "max": 10,
+      "default": 0.015,
+      "step": 0.001,
+      "unit": "Ω"
+    },
+    "max_current": {
+      "displayName": "Max Expected Current",
+      "description": "Maximum expected current, used for calibration.",
+      "type": "float",
+      "min": 0.1,
+      "max": 20,
+      "default": 10,
+      "step": 0.1,
+      "unit": "A"
+    },
     "adc_range": {
       "displayName": "ADC Range",
       "description": "Shunt voltage measurement range.",

--- a/components/i2c/ina238/definition.json
+++ b/components/i2c/ina238/definition.json
@@ -6,5 +6,46 @@
   "description": "85V, 16-bit, high-precision power monitor (up to 10A, 0.1% gain error)",
   "published": true,
   "i2cAddresses": [ "0x40", "0x41", "0x44", "0x45" ],
+  "settings": {
+    "adc_range": {
+      "displayName": "ADC Range",
+      "description": "Shunt voltage measurement range.",
+      "default": 0,
+      "options": ["±163.84 mV", "±40.96 mV"]
+    },
+    "averaged_samples": {
+      "displayName": "Averaged Samples",
+      "default": 2,
+      "options": ["1", "4", "16", "64", "128", "256", "512", "1024"]
+    },
+    "voltage_conversion_time": {
+      "displayName": "Voltage Conversion Time",
+      "default": 2,
+      "options": [
+        "50 µs",
+        "84 µs",
+        "150 µs",
+        "280 µs",
+        "540 µs",
+        "1052 µs",
+        "2074 µs",
+        "4120 µs"
+      ]
+    },
+    "current_conversion_time": {
+      "displayName": "Current Conversion Time",
+      "default": 3,
+      "options": [
+        "50 µs",
+        "84 µs",
+        "150 µs",
+        "280 µs",
+        "540 µs",
+        "1052 µs",
+        "2074 µs",
+        "4120 µs"
+      ]
+    }
+  },
   "subcomponents": [ "voltage", "current" ]
 }

--- a/components/i2c/ina260/definition.json
+++ b/components/i2c/ina260/definition.json
@@ -5,5 +5,45 @@
   "documentationURL": "https://learn.adafruit.com/adafruit-ina260-current-voltage-power-sensor-breakout",
   "published": true,
   "i2cAddresses": [ "0x40", "0x41", "0x44", "0x45" ],
+  "settings": {
+    "averaged_samples": {
+      "displayName": "Averaged Samples",
+      "default": 2,
+      "options": ["1", "4", "16", "64", "128", "256", "512", "1024"]
+    },
+    "voltage_conversion_time": {
+      "displayName": "Voltage Conversion Time",
+      "default": 0,
+      "options": [
+        "140 µs",
+        "204 µs",
+        "332 µs",
+        "588 µs",
+        "1.1 ms",
+        "2.116 ms",
+        "4.156 ms",
+        "8.244 ms"
+      ]
+    },
+    "current_conversion_time": {
+      "displayName": "Current Conversion Time",
+      "default": 0,
+      "options": [
+        "140 µs",
+        "204 µs",
+        "332 µs",
+        "588 µs",
+        "1.1 ms",
+        "2.116 ms",
+        "4.156 ms",
+        "8.244 ms"
+      ]
+    },
+    "mode": {
+      "displayName": "Mode",
+      "default": 2,
+      "options": ["Shutdown", "Triggered", "Continuous"]
+    }
+  },
   "subcomponents": [ "voltage", "current" ]
 }

--- a/components/i2c/lps28dfw/definition.json
+++ b/components/i2c/lps28dfw/definition.json
@@ -6,5 +6,37 @@
   "description": "From 260 to 4060 hPa, this is our largest range pressure sensor (24bit).",
   "published": true,
   "i2cAddresses": [ "0x5C", "0x5D" ],
+  "settings": {
+    "output_data_rate": {
+      "displayName": "Output Data Rate",
+      "default": 0,
+      "options": [
+        "One-shot",
+        "1 Hz",
+        "4 Hz",
+        "10 Hz",
+        "25 Hz",
+        "50 Hz",
+        "75 Hz",
+        "100 Hz",
+        "200 Hz"
+      ]
+    },
+    "averaged_samples": {
+      "displayName": "Averaged Samples",
+      "default": 6,
+      "options": ["4", "8", "16", "32", "64", "128", "512"]
+    },
+    "range": {
+      "displayName": "Pressure Range",
+      "default": 1,
+      "options": ["1260 hPa", "4060 hPa"]
+    },
+    "filter": {
+      "displayName": "Low-pass Filter",
+      "default": 0,
+      "options": ["Off", "Low-pass (ODR/9)"]
+    }
+  },
   "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "pressure" ]
 }

--- a/components/i2c/mlx90632b/definition.json
+++ b/components/i2c/mlx90632b/definition.json
@@ -6,6 +6,27 @@
   "documentationURL": "https://cdn-shop.adafruit.com/product-files/6403/MLX90632-Datasheet-Melexis.PDF",
   "published": true,
   "i2cAddresses": ["0x3A", "0x3B"],
+  "settings": {
+    "mode": {
+      "displayName": "Measurement Mode",
+      "default": 0,
+      "options": ["Continuous", "Step", "Sleeping Step", "Halt"]
+    },
+    "measurement_rate": {
+      "displayName": "Refresh Rate",
+      "default": 2,
+      "options": [
+        "0.5 Hz",
+        "1 Hz",
+        "2 Hz",
+        "4 Hz",
+        "8 Hz",
+        "16 Hz",
+        "32 Hz",
+        "64 Hz"
+      ]
+    }
+  },
   "subcomponents": [
     {
       "displayName": "Ambient Temperature (°C)",

--- a/components/i2c/mlx90632d_ext/definition.json
+++ b/components/i2c/mlx90632d_ext/definition.json
@@ -6,6 +6,27 @@
   "documentationURL": "https://cdn-shop.adafruit.com/product-files/6403/MLX90632-Datasheet-Melexis.PDF",
   "published": true,
   "i2cAddresses": ["0x3A", "0x3B"],
+  "settings": {
+    "mode": {
+      "displayName": "Measurement Mode",
+      "default": 0,
+      "options": ["Continuous", "Step", "Sleeping Step", "Halt"]
+    },
+    "measurement_rate": {
+      "displayName": "Refresh Rate",
+      "default": 2,
+      "options": [
+        "0.5 Hz",
+        "1 Hz",
+        "2 Hz",
+        "4 Hz",
+        "8 Hz",
+        "16 Hz",
+        "32 Hz",
+        "64 Hz"
+      ]
+    }
+  },
   "subcomponents": [
     {
       "displayName": "Ambient Temperature (°C)",

--- a/components/i2c/mlx90632d_med/definition.json
+++ b/components/i2c/mlx90632d_med/definition.json
@@ -6,6 +6,27 @@
   "documentationURL": "https://cdn-shop.adafruit.com/product-files/6403/MLX90632-Datasheet-Melexis.PDF",
   "published": true,
   "i2cAddresses": ["0x3A", "0x3B"],
+  "settings": {
+    "mode": {
+      "displayName": "Measurement Mode",
+      "default": 0,
+      "options": ["Continuous", "Step", "Sleeping Step", "Halt"]
+    },
+    "measurement_rate": {
+      "displayName": "Refresh Rate",
+      "default": 2,
+      "options": [
+        "0.5 Hz",
+        "1 Hz",
+        "2 Hz",
+        "4 Hz",
+        "8 Hz",
+        "16 Hz",
+        "32 Hz",
+        "64 Hz"
+      ]
+    }
+  },
   "subcomponents": [
     {
       "displayName": "Ambient Temperature (°C)",

--- a/components/i2c/schema.json
+++ b/components/i2c/schema.json
@@ -4,35 +4,88 @@
   "type": "object",
   "$defs": {
     "setting": {
-      "type": "object",
-      "description": "A configurable device setting. Firmware receives the selected option's 0-based index.",
-      "required": ["displayName", "options"],
-      "additionalProperties": false,
-      "properties": {
-        "displayName": {
-          "description": "Human-readable label shown in the UI.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 30
+      "description": "A configurable device setting. Option-based settings send the selected option's 0-based index to firmware; numeric settings send the entered value directly.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "An option-based setting. Firmware receives the selected option's 0-based index.",
+          "required": ["displayName", "options"],
+          "additionalProperties": false,
+          "properties": {
+            "displayName": {
+              "description": "Human-readable label shown in the UI.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 30
+            },
+            "description": {
+              "description": "Optional helper text explaining what this setting controls.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255
+            },
+            "default": {
+              "description": "Index of the default option (0-based). Defaults to 0 if omitted.",
+              "type": "integer",
+              "minimum": 0
+            },
+            "options": {
+              "description": "Ordered list of option labels. The selected index is sent to firmware.",
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 2
+            }
+          }
         },
-        "description": {
-          "description": "Optional helper text explaining what this setting controls.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 255
-        },
-        "default": {
-          "description": "Index of the default option (0-based). Defaults to 0 if omitted.",
-          "type": "integer",
-          "minimum": 0
-        },
-        "options": {
-          "description": "Ordered list of option labels. The selected index is sent to firmware.",
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 2
+        {
+          "type": "object",
+          "description": "A numeric setting. The entered value is sent directly to firmware (as an int or float), not an option index.",
+          "required": ["displayName", "type"],
+          "additionalProperties": false,
+          "properties": {
+            "displayName": {
+              "description": "Human-readable label shown in the UI.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 30
+            },
+            "description": {
+              "description": "Optional helper text explaining what this setting controls.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 255
+            },
+            "type": {
+              "description": "Numeric value type sent to firmware.",
+              "type": "string",
+              "enum": ["int", "float"]
+            },
+            "min": {
+              "description": "Minimum allowed value.",
+              "type": "number"
+            },
+            "max": {
+              "description": "Maximum allowed value.",
+              "type": "number"
+            },
+            "default": {
+              "description": "Default value sent to firmware (not an index).",
+              "type": "number"
+            },
+            "step": {
+              "description": "Increment for the UI control.",
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "unit": {
+              "description": "Optional unit label shown next to the value.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 12
+            }
+          }
         }
-      }
+      ]
     },
     "subcomponent": {
       "type": ["string", "object"],

--- a/components/i2c/spa06_003/definition.json
+++ b/components/i2c/spa06_003/definition.json
@@ -6,5 +6,31 @@
   "description": "300-1100hPa (-500 to 9000m) Relative accuracy ±3Pa (±0.25 meter), absolute ±30Pa (±2.5m). Temperature ±1°C",
   "published": true,
   "i2cAddresses": [ "0x77", "0x76" ],
+  "settings": {
+    "temp_oversampling": {
+      "displayName": "Temperature Oversampling",
+      "default": 0,
+      "options": ["1x", "2x", "4x", "8x", "16x", "32x", "64x", "128x"]
+    },
+    "pressure_oversampling": {
+      "displayName": "Pressure Oversampling",
+      "default": 0,
+      "options": ["1x", "2x", "4x", "8x", "16x", "32x", "64x", "128x"]
+    },
+    "output_data_rate": {
+      "displayName": "Output Data Rate",
+      "default": 0,
+      "options": [
+        "1 Hz",
+        "2 Hz",
+        "4 Hz",
+        "8 Hz",
+        "16 Hz",
+        "32 Hz",
+        "64 Hz",
+        "128 Hz"
+      ]
+    }
+  },
   "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "pressure" ]
 }

--- a/components/i2c/vcnl4030/definition.json
+++ b/components/i2c/vcnl4030/definition.json
@@ -6,5 +6,41 @@
   "documentationURL": "https://learn.adafruit.com/adafruit-vcnl4030-proximity-and-lux-sensor",
   "published": true,
   "i2cAddresses": ["0x60"],
+  "settings": {
+    "integration_time": {
+      "displayName": "ALS Integration Time",
+      "default": 1,
+      "options": ["50 ms", "100 ms", "200 ms", "400 ms", "800 ms"]
+    },
+    "prox_led_current": {
+      "displayName": "Proximity LED Current",
+      "default": 7,
+      "options": [
+        "50 mA",
+        "75 mA",
+        "100 mA",
+        "120 mA",
+        "140 mA",
+        "160 mA",
+        "180 mA",
+        "200 mA"
+      ]
+    },
+    "prox_duty": {
+      "displayName": "Proximity Duty Cycle",
+      "default": 0,
+      "options": ["1/40", "1/80", "1/160", "1/320"]
+    },
+    "prox_integration_time": {
+      "displayName": "Proximity Integration Time",
+      "default": 7,
+      "options": ["1T", "1.5T", "2T", "2.5T", "3T", "3.5T", "4T", "8T"]
+    },
+    "prox_resolution": {
+      "displayName": "Proximity Resolution",
+      "default": 1,
+      "options": ["12-bit", "16-bit"]
+    }
+  },
   "subcomponents": ["light", "proximity"]
 }

--- a/components/i2c/vcnl4200/definition.json
+++ b/components/i2c/vcnl4200/definition.json
@@ -6,5 +6,41 @@
   "description": "Proximity sensor works from 0 to 1.5m (about 59 inches) & light sensor with range of 0.003 to 1570 lux",
   "published": true,
   "i2cAddresses": [ "0x51" ],
+  "settings": {
+    "integration_time": {
+      "displayName": "ALS Integration Time",
+      "default": 3,
+      "options": ["50 ms", "100 ms", "200 ms", "400 ms"]
+    },
+    "prox_led_current": {
+      "displayName": "Proximity LED Current",
+      "default": 7,
+      "options": [
+        "50 mA",
+        "75 mA",
+        "100 mA",
+        "120 mA",
+        "140 mA",
+        "160 mA",
+        "180 mA",
+        "200 mA"
+      ]
+    },
+    "prox_duty": {
+      "displayName": "Proximity Duty Cycle",
+      "default": 0,
+      "options": ["1/160", "1/320", "1/640", "1/1280"]
+    },
+    "prox_integration_time": {
+      "displayName": "Proximity Integration Time",
+      "default": 5,
+      "options": ["1T", "2T", "3T", "4T", "8T", "9T"]
+    },
+    "prox_resolution": {
+      "displayName": "Proximity Resolution",
+      "default": 1,
+      "options": ["12-bit", "16-bit"]
+    }
+  },
   "subcomponents": [ "light", "proximity" ]
 }


### PR DESCRIPTION
### Overview

Adds `settings` blocks to the I2C components whose firmware drivers were backported with configurable options in [Adafruit_Wippersnapper_Arduino#933](https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/pull/933) — the components-side counterpart, in the same spirit as #327. Setting option order and default index match the firmware `set*` mapping / `configureDefaults()`.

### Schema change

Extends `components/i2c/schema.json` `$defs/setting` to a `oneOf` supporting **two kinds** of setting:
- **option-based** (unchanged) — firmware receives the selected option's 0-based index.
- **numeric** (new) — `type` of `"int"` or `"float"` with optional `min`/`max`/`default`/`step`/`unit`; firmware receives the entered value directly via `ws.config.Value` (int/float), not an index.

### Option settings added

ina260, ina237/238/228, lps28dfw, spa06_003, htu31d, hdc302x, as7331, as5600, mlx90632b/d_med/d_ext, vcnl4200/4030 — gains, integration/conversion times, modes, oversampling, rates, resolutions, etc.

### Numeric settings added (new type)

- `sea_level_pressure` (hPa) on the BMP/BME altitude components: bme280, bme680, bme688, bmp280, bmp388, bmp390, bmp580, bmp581, bmp585.
- `shunt_resistance` (Ω) and `max_current` (A) on ina237, ina238, ina228.
- `z_position`, `m_position`, `max_angle` (raw 12-bit) on as5600.

All 94 i2c definitions validate against the updated schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)