### PR TITLE
fix(scd4x): Add SCD43 and split out SCD40 / SCD41

### DIFF
--- a/components/i2c/scd40/definition.json
+++ b/components/i2c/scd40/definition.json
@@ -1,6 +1,7 @@
 {
-  "displayName": "SCD40/SCD41",
+  "displayName": "SCD40",
   "vendor": "Sensirion",
+  "description": "Temperature, Humidity and CO2 measurements. With a range of 400~2000 ppm and an accuracy of ±(50ppm + 5%)",
   "productURL": "https://www.adafruit.com/product/5187",
   "documentationURL": "https://learn.adafruit.com/adafruit-scd-40-and-scd-41",
   "published": true,

--- a/components/i2c/scd41/definition.json
+++ b/components/i2c/scd41/definition.json
@@ -1,0 +1,10 @@
+{
+  "displayName": "SCD41",
+  "vendor": "Sensirion",
+  "description": "Temperature, Humidity and CO2 measurements. With a range of 400~5000 ppm and an accuracy of ±(40ppm + 5%)",
+  "productURL": "https://www.adafruit.com/product/5190",
+  "documentationURL": "https://learn.adafruit.com/adafruit-scd-40-and-scd-41",
+  "published": false,
+  "i2cAddresses": ["0x62"],
+  "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "humidity", "co2" ]
+}

--- a/components/i2c/scd43/definition.json
+++ b/components/i2c/scd43/definition.json
@@ -1,0 +1,10 @@
+{
+  "displayName": "SCD43",
+  "vendor": "Sensirion",
+  "description": "Temperature, Humidity and CO2 measurements. With a range of 400~5000 ppm and an accuracy of ±(30ppm + 3%)",
+  "productURL": "https://www.adafruit.com/product/6512",
+  "documentationURL": "https://learn.adafruit.com/adafruit-scd-40-and-scd-41",
+  "published": false,
+  "i2cAddresses": ["0x62"],
+  "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "humidity", "co2" ]
+}


### PR DESCRIPTION
Adds the SCD43. 
Adds descriptions to the existing shared SCD40\41 component, to specify the differing measurement ranges, splitting them out and leaving separate SCD40 SCD41 and SCD43 components. 

The publish is false for the 43 and 41, ~but 41 is already supported in the arduino firmware so can be published true~(`~` = only true for v2). 

Older user components were originally labelled SCD40/41 and will now be SCD40.