### PR TITLE
Publish scd41 43

### DIFF
--- a/components/i2c/scd41/definition.json
+++ b/components/i2c/scd41/definition.json
@@ -4,7 +4,7 @@
   "description": "Temperature, Humidity and CO2 measurements. With a range of 400~5000 ppm and an accuracy of ±(40ppm + 5%)",
   "productURL": "https://www.adafruit.com/product/5190",
   "documentationURL": "https://learn.adafruit.com/adafruit-scd-40-and-scd-41",
-  "published": false,
+  "published": true,
   "i2cAddresses": ["0x62"],
   "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "humidity", "co2" ]
 }

--- a/components/i2c/scd43/definition.json
+++ b/components/i2c/scd43/definition.json
@@ -4,7 +4,7 @@
   "description": "Temperature, Humidity and CO2 measurements. With a range of 400~5000 ppm and an accuracy of ±(30ppm + 3%)",
   "productURL": "https://www.adafruit.com/product/6512",
   "documentationURL": "https://learn.adafruit.com/adafruit-scd-40-and-scd-41",
-  "published": false,
+  "published": true,
   "i2cAddresses": ["0x62"],
   "subcomponents": [ "ambient-temp", "ambient-temp-fahrenheit", "humidity", "co2" ]
 }


### PR DESCRIPTION
Tested on release v1b132, CI assets before release generation (main branch after version bump).
Both performs fine with the older component name, and the new ones. Only current firmware will support new defs.